### PR TITLE
Updage zendesk/checkout action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
Solve the warning around deprecated Node 12 actions in the CI checks of this repo by upgrading `zendesk/checkout` to v3. See warning here https://github.com/zendesk/action-create-release/actions/runs/3412790996